### PR TITLE
expose `ShardingEvent` types

### DIFF
--- a/.changeset/tasty-carpets-talk.md
+++ b/.changeset/tasty-carpets-talk.md
@@ -2,4 +2,4 @@
 "@effect/cluster": patch
 ---
 
-Exposes types of indiviual `ShardingEvent` union members which were previously unexposed despite appearing in the signatures of exposed functions
+Expose types of indiviual `ShardingEvent` union members which were previously unexposed despite appearing in the signatures of exposed functions

--- a/.changeset/tasty-carpets-talk.md
+++ b/.changeset/tasty-carpets-talk.md
@@ -1,0 +1,5 @@
+---
+"@effect/cluster": patch
+---
+
+Exposes types of indiviual `ShardingEvent` union members which were previously unexposed despite appearing in the signatures of exposed functions

--- a/packages/cluster/src/ShardingEvent.ts
+++ b/packages/cluster/src/ShardingEvent.ts
@@ -5,6 +5,10 @@ import type * as HashSet from "effect/HashSet"
 import type * as PodAddress from "./PodAddress.js"
 import type * as ShardId from "./ShardId.js"
 
+/**
+ * @since 1.0.0
+ * @category models
+ */
 export interface ShardsAssigned {
   readonly _tag: "ShardsAssigned"
   readonly pod: PodAddress.PodAddress
@@ -24,6 +28,10 @@ export function ShardsAssigned(
   return { _tag: "ShardsAssigned", pod, shards }
 }
 
+/**
+ * @since 1.0.0
+ * @category models
+ */
 export interface ShardsUnassigned {
   readonly _tag: "ShardsUnassigned"
   readonly pod: PodAddress.PodAddress
@@ -42,6 +50,10 @@ export function ShardsUnassigned(
   return { _tag: "ShardsUnassigned", pod, shards }
 }
 
+/**
+ * @since 1.0.0
+ * @category models
+ */
 export interface PodHealthChecked {
   readonly _tag: "PodHealthChecked"
   readonly pod: PodAddress.PodAddress
@@ -57,6 +69,10 @@ export function PodHealthChecked(pod: PodAddress.PodAddress): PodHealthChecked {
   return { _tag: "PodHealthChecked", pod }
 }
 
+/**
+ * @since 1.0.0
+ * @category models
+ */
 export interface PodRegistered {
   readonly _tag: "PodRegistered"
   readonly pod: PodAddress.PodAddress
@@ -72,6 +88,11 @@ export function PodRegistered(pod: PodAddress.PodAddress): PodRegistered {
   return { _tag: "PodRegistered", pod }
 }
 
+
+/**
+ * @since 1.0.0
+ * @category models
+ */
 export interface PodUnregistered {
   readonly _tag: "PodUnregistered"
   readonly pod: PodAddress.PodAddress

--- a/packages/cluster/src/ShardingEvent.ts
+++ b/packages/cluster/src/ShardingEvent.ts
@@ -5,7 +5,7 @@ import type * as HashSet from "effect/HashSet"
 import type * as PodAddress from "./PodAddress.js"
 import type * as ShardId from "./ShardId.js"
 
-interface ShardsAssigned {
+export interface ShardsAssigned {
   readonly _tag: "ShardsAssigned"
   readonly pod: PodAddress.PodAddress
   readonly shards: HashSet.HashSet<ShardId.ShardId>
@@ -24,7 +24,7 @@ export function ShardsAssigned(
   return { _tag: "ShardsAssigned", pod, shards }
 }
 
-interface ShardsUnassigned {
+export interface ShardsUnassigned {
   readonly _tag: "ShardsUnassigned"
   readonly pod: PodAddress.PodAddress
   readonly shards: HashSet.HashSet<ShardId.ShardId>
@@ -42,7 +42,7 @@ export function ShardsUnassigned(
   return { _tag: "ShardsUnassigned", pod, shards }
 }
 
-interface PodHealthChecked {
+export interface PodHealthChecked {
   readonly _tag: "PodHealthChecked"
   readonly pod: PodAddress.PodAddress
 }
@@ -57,7 +57,7 @@ export function PodHealthChecked(pod: PodAddress.PodAddress): PodHealthChecked {
   return { _tag: "PodHealthChecked", pod }
 }
 
-interface PodRegistered {
+export interface PodRegistered {
   readonly _tag: "PodRegistered"
   readonly pod: PodAddress.PodAddress
 }
@@ -72,7 +72,7 @@ export function PodRegistered(pod: PodAddress.PodAddress): PodRegistered {
   return { _tag: "PodRegistered", pod }
 }
 
-interface PodUnregistered {
+export interface PodUnregistered {
   readonly _tag: "PodUnregistered"
   readonly pod: PodAddress.PodAddress
 }


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please ensure you've done the following:

- 📖 Read our Contributing Guide: https://github.com/effect-ts/.github/blob/main/CONTRIBUTING.md
- 📖 Read our Code of Conduct: https://github.com/effect-ts/.github/blob/main/CODE_OF_CONDUCT.md
- 👷‍♀️ Create small PRs. In most cases this will be possible.
- 📝 Use descriptive commit messages.
- ✅ Provide tests for your changes if applicable.
- 📗 If your change requires documentation, please update the relevant documentation.
- 📝 Create a changeset for your changes. This helps in tracking and communicating the changes effectively.
- ⏳ Please be patient! We will do our best to review your pull request as soon as possible.

NOTE: Pull Requests from forked repositories will need to be reviewed by a team member before any CI builds will run.
-->

## Type

<!--
What type of change is this? Please check all applicable.
-->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--
Please add a brief summary/description of the pull request here.
-->

This PR:
Exposes types of individual `ShardingEvent` union members which were previously unexposed despite appearing in the signatures of exposed functions

## Related

<!--
For pull requests that relate or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234 and automatically
close the issue once we merge the pull request.
-->

- Related Issue #
- Closes #
